### PR TITLE
Dirty fixes & QOL Changes

### DIFF
--- a/dndtools.py
+++ b/dndtools.py
@@ -9,15 +9,15 @@ if __name__ == '__main__':
     print("Welcome to DnDTools, enter a number for the function you want to execute")
     f = "{}  {:<20}|" + (" " * 10) + "{:<20}"
     fns = [
-        (1, "Find Monster", "allows you to search for a monster", monsterfinder.main),
-        (2, "Start Encounter", "start an encounter from the encounters you have created", sandbox.main),
-        (3, "Create encounter", "create an encounter which can then be played", encounter_generator.generate_ecnounter_io),
-        (4, "Generate loot", "generates random loot", misc.loot_fn),
-        (5, "Create monster", "creates a monster that can then be added to an encounter", 0),
-        (6, "view encounter", "shows the availible encounters", ecnounter_finder.display)
+        (1, "Find Monster", "Allows you to search for a monster", monsterfinder.main),
+        (2, "Start Encounter", "Start an encounter from the encounters you have created", sandbox.main),
+        (3, "Create encounter", "Create an encounter which can then be played", encounter_generator.generate_ecnounter_io),
+        (4, "Generate loot", "Generates random loot", misc.loot_fn),
+        (5, "Create monster", "Creates a monster that can then be added to an encounter", 0),
+        (6, "view encounter", "Shows the available encounters", ecnounter_finder.display)
     ]
     def print_fns():
-        print(f.format("#", "Name", "description"))
+        print(f.format("#", "Name", "Description"))
         for fn in fns:
             print(f.format(*fn[0:-1]))
 

--- a/ecnounter_finder.py
+++ b/ecnounter_finder.py
@@ -22,7 +22,8 @@ def main():
 def display():
     data = main()
     inp = input("select encounter to describe")
-    with open(data[int(inp)], "r") as f:
+    split = data[int(inp)].split("\\") #data[int(inp)] is encounter\"name", when only "name" is needed. Therefore, the string is split
+    with open(split[1], "r") as f:
         print(json.dumps(json.load(f), indent=4))
 
 if __name__ == '__main__':

--- a/encounter_input.py
+++ b/encounter_input.py
@@ -7,14 +7,14 @@ help_msg = """
 (d) damage <to> <amount> deals damage to the specified creature
 (h) heal <to> <amount> heals the specified creature
 (u) undo undoes the last action
-(E) end ends the encounter with prompt
-(R) roll <dice> should roll a dice in the format of <amnt>d<eyes>
+(e) end ends the encounter with prompt
+(r) roll <dice> should roll a dice in the format of <amnt>d<eyes>
 (n) next continues to the next turn with a prompt
 (more) <creature> shows details to creature
 (help, ?) shows help dialog
 """
 
-short_help = "(s)how, (d)amage, (h)eal, (u)ndo, (E)nd, (R)oll, (n)ext, more #, (?)"
+short_help = "(s)how, (d)amage, (h)eal, (u)ndo, (e)nd, (r)oll, (n)ext, more #, (?)"
 
 
 def promptYN(msg="are you sure?[y/N] "):
@@ -157,8 +157,8 @@ class EncounterInput:
             ["d", "damage", self.damage],
             ["h", "heal", self.heal],
             ["u", "undo", self.undo],
-            ["E", "end", self.end],
-            ["R", "roll", self.roll],
+            ["e", "end", self.end],
+            ["r", "roll", self.roll],
             ["n", "next", self.next],
             ["m", "more", self.more],
             ["help", "?", self.help]

--- a/monsterfinder.py
+++ b/monsterfinder.py
@@ -5,14 +5,16 @@ import json
 def main():
     data = load.load_files()
     parser = argparse.ArgumentParser()
-    parser.add_argument("lookup", help="the lookup")
+    parser.add_argument("--lookup", help="the lookup")
     args = parser.parse_args()
+    print("Enter name of Monster: ")
+    args.lookup = input()
     print("looking for monster with lookup: ", args.lookup)
     res = data.search(args.lookup)
     found, key, _, certainty = res
     try:
         monster = data[key]
-        print("found a monster with a probability of ", 100 * certainty, "%", key, ":")
+        print("found a monster with a probability of ", 100 * certainty, "%: ", "'", key, "'")
         yesno = input("show monster details [Y/n]")
         if not yesno.lower() == "n":
             print(json.dumps(monster, indent=4))

--- a/sandbox.py
+++ b/sandbox.py
@@ -8,9 +8,11 @@ def main():
     print("select the encounter you want to choose from below: ")
     enc = ecnounter_finder.main()
     enc_num = int(input("encounter number: "))
+    path = enc[enc_num]
+    split = path.split("\\") #enc[enum] is encounter\"name", when only "name" is needed. Therefore, Encounter.load would break if using it
     playable_encounter = encounter_generator.PlayableEncouter.from_encounter(
         load.load_files(),
-        encounter_generator.Encounter.load(enc[enc_num])
+        encounter_generator.Encounter.load(split[1])
     )
     display = encounter_display.Display(playable_encounter)
     inp = encounter_input.EncounterInput(playable_encounter, display)


### PR DESCRIPTION
-Uppercased some things
-Fixed a bug in encounterFinder and sandbox:
Encounter-names are displayed as "encounter\\name", which breaks some code. Dirtily Fixed by splitting the String
-Dirtily fixed the monsterfinder

Signed-off-by: Van-Jay Pham <pha17026@spengergasse.at>